### PR TITLE
Revert removal of GL asserts (which hang some machines) (Leo)

### DIFF
--- a/modules/juce_opengl/juce_opengl.cpp
+++ b/modules/juce_opengl/juce_opengl.cpp
@@ -148,8 +148,9 @@ static void checkGLError (const char* file, const int line)
 
         if (e == GL_NO_ERROR)
             break;
-		    DBG ("***** " << getGLErrorMessage (e) << "  at " << file << " : " << line);
-		    jassertfalse;
+		// TODO: Handle GL errors on Install/Run
+		//DBG ("***** " << getGLErrorMessage (e) << "  at " << file << " : " << line);
+		//jassertfalse;
 	}
 }
 

--- a/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.cpp
+++ b/modules/juce_opengl/opengl/juce_OpenGLShaderProgram.cpp
@@ -22,6 +22,10 @@
   ==============================================================================
 */
 
+// Avoid asserts  
+// ToDo: Handle errors
+#define JUCE_DONT_ASSERT_ON_GLSL_COMPILE_ERROR 1
+
 OpenGLShaderProgram::OpenGLShaderProgram (const OpenGLContext& c) noexcept
     : context (c), programID (0)
 {


### PR DESCRIPTION
Remove GL asserts because they cause some machines to hang.

These asserts serve no useful purpose now. 
they just delay Element startup or hang the machine.

Fixing the underlying GL extension issues is on the agenda,
These asserts are not needed in the meantime.

